### PR TITLE
Fix typo on ./configure in README

### DIFF
--- a/README
+++ b/README
@@ -40,7 +40,7 @@ Basic Instructions:
 + Download the install the ITL-tools (ie. itools package)
   - Compile the package
     $ autoreconf -f -i
-    $ configure
+    $ ./configure
     $ make
   - To install post a succesful compilation,
     $ make install


### PR DESCRIPTION
This patch fixes a README typo, changing `configure` to `./configure`.